### PR TITLE
Refactor settings

### DIFF
--- a/eb_sqs_worker/app_settings.py
+++ b/eb_sqs_worker/app_settings.py
@@ -1,0 +1,73 @@
+import warnings
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+class AppSettings:
+    def __init__(self):
+        self._enabled_tasks = {}
+        self._queues = {}
+
+    @property
+    def AWS_EB_DEFAULT_REGION(self):
+        return self._get_setting('AWS_EB_DEFAULT_REGION')
+
+    @property
+    def AWS_ACCESS_KEY_ID(self):
+        return self._get_setting('AWS_ACCESS_KEY_ID')
+
+    @property
+    def AWS_SECRET_ACCESS_KEY(self):
+        return self._get_setting('AWS_SECRET_ACCESS_KEY')
+
+    @property
+    def AWS_EB_DEFAULT_QUEUE_NAME(self):
+        return self._get_setting('AWS_EB_DEFAULT_QUEUE_NAME', raise_exception=False, default='django-eb-sqs-worker')
+
+    @property
+    def AWS_EB_HANDLE_SQS_TASKS(self):
+        return self._get_setting('AWS_EB_HANDLE_SQS_TASKS', raise_exception=False, default=False)
+
+    @property
+    def AWS_EB_RUN_TASKS_LOCALLY(self):
+        return self._get_setting('AWS_EB_RUN_TASKS_LOCALLY', raise_exception=False, default=False)
+
+    @property
+    def AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS(self):
+        return self._get_setting('AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS', raise_exception=False)
+
+    @property
+    def enabled_tasks(self):
+        self._enabled_tasks = self._get_setting('AWS_EB_ENABLED_TASKS', raise_exception=False, default={})
+        if not isinstance(self._enabled_tasks, dict):
+            raise ImproperlyConfigured(f"settings.EB_SQS[AWS_EB_ENABLED_TASKS] must be a dict, "
+                                       f"not {type(self._enabled_tasks)}")
+
+        return self._enabled_tasks
+
+    def get_queue_by_name(self, queue_name):
+        if queue_name not in self._queues:
+            from .sqs import sqs  # Avoid circular import
+            self._queues[queue_name] = sqs.get_queue_by_name(QueueName=queue_name)
+
+        return self._queues[queue_name]
+
+    @staticmethod
+    def _get_setting(name, raise_exception=True, default=None):
+        # We cannot cache this on the instance, because Django's override_settings used
+        # in test will no longer work.
+        try:
+            return getattr(settings, 'EB_SQS', {})[name]
+        except KeyError:
+            if hasattr(settings, name):
+                warnings.warn(f"Setting {name} should be migrated to 'settings.EB_SQS' dictionary.", DeprecationWarning)
+                return getattr(settings, name)
+
+
+        if raise_exception:
+            raise ImproperlyConfigured(f"settings.EB_SQS[{name}] should be set.")
+        else:
+            return default
+
+app_settings = AppSettings()

--- a/eb_sqs_worker/app_settings.py
+++ b/eb_sqs_worker/app_settings.py
@@ -2,49 +2,58 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import cached_property
 
 
 class AppSettings:
     def __init__(self):
-        self._enabled_tasks = {}
         self._queues = {}
 
-    @property
+    @cached_property
     def AWS_EB_DEFAULT_REGION(self):
         return self._get_setting('AWS_EB_DEFAULT_REGION')
 
-    @property
+    @cached_property
     def AWS_ACCESS_KEY_ID(self):
         return self._get_setting('AWS_ACCESS_KEY_ID')
 
-    @property
+    @cached_property
     def AWS_SECRET_ACCESS_KEY(self):
         return self._get_setting('AWS_SECRET_ACCESS_KEY')
 
-    @property
+    @cached_property
     def AWS_EB_DEFAULT_QUEUE_NAME(self):
-        return self._get_setting('AWS_EB_DEFAULT_QUEUE_NAME', raise_exception=False, default='django-eb-sqs-worker')
+        return self._get_setting('AWS_EB_DEFAULT_QUEUE_NAME',
+                                 raise_exception=False,
+                                 default='django-eb-sqs-worker')
 
-    @property
+    @cached_property
     def AWS_EB_HANDLE_SQS_TASKS(self):
-        return self._get_setting('AWS_EB_HANDLE_SQS_TASKS', raise_exception=False, default=False)
+        return self._get_setting('AWS_EB_HANDLE_SQS_TASKS',
+                                 raise_exception=False,
+                                 default=False)
 
-    @property
+    @cached_property
     def AWS_EB_RUN_TASKS_LOCALLY(self):
-        return self._get_setting('AWS_EB_RUN_TASKS_LOCALLY', raise_exception=False, default=False)
+        return self._get_setting('AWS_EB_RUN_TASKS_LOCALLY',
+                                 raise_exception=False,
+                                 default=False)
 
-    @property
+    @cached_property
     def AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS(self):
-        return self._get_setting('AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS', raise_exception=False)
+        return self._get_setting('AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS',
+                                 raise_exception=False)
 
-    @property
+    @cached_property
     def enabled_tasks(self):
-        self._enabled_tasks = self._get_setting('AWS_EB_ENABLED_TASKS', raise_exception=False, default={})
-        if not isinstance(self._enabled_tasks, dict):
-            raise ImproperlyConfigured(f"settings.EB_SQS[AWS_EB_ENABLED_TASKS] must be a dict, "
-                                       f"not {type(self._enabled_tasks)}")
+        enabled_tasks = self._get_setting('AWS_EB_ENABLED_TASKS',
+                                          raise_exception=False,
+                                          default={})
+        if not isinstance(enabled_tasks, dict):
+            raise ImproperlyConfigured(f"settings.EB_SQS[AWS_EB_ENABLED_TASKS]"
+                                       f" must be a dict, not {type(enabled_tasks)}")
 
-        return self._enabled_tasks
+        return enabled_tasks
 
     def get_queue_by_name(self, queue_name):
         if queue_name not in self._queues:
@@ -61,7 +70,8 @@ class AppSettings:
             return getattr(settings, 'EB_SQS', {})[name]
         except KeyError:
             if hasattr(settings, name):
-                warnings.warn(f"Setting {name} should be migrated to 'settings.EB_SQS' dictionary.", DeprecationWarning)
+                warnings.warn(f"Setting {name} should be migrated"
+                              f" to 'settings.EB_SQS' dictionary.", DeprecationWarning)
                 return getattr(settings, name)
 
 
@@ -69,5 +79,19 @@ class AppSettings:
             raise ImproperlyConfigured(f"settings.EB_SQS[{name}] should be set.")
         else:
             return default
+
+    def reconfigure(self):
+        """
+        Method for testing
+
+        Since tests modify settings at runtime, this can be used to reset values that
+        should normally only be hydrated once at application startup.
+        """
+        self._queues = {}
+        self.__dict__ = {
+            k: v for k, v in self.__dict__.items()
+            if not k.startswith('AWS_')
+        }
+        self.__dict__.pop('enabled_tasks', None)
 
 app_settings = AppSettings()

--- a/eb_sqs_worker/tests.py
+++ b/eb_sqs_worker/tests.py
@@ -1,7 +1,8 @@
 import json
+import sys
 
 from django.core.exceptions import ImproperlyConfigured
-from django.test import TestCase, Client, RequestFactory
+from django.test import TestCase as BaseTestCase, Client, RequestFactory
 # Create your tests here.
 from django.urls import reverse
 from django.utils import timezone
@@ -14,11 +15,16 @@ def update_settings(**kwargs):
     return defaults
 
 
+class TestCase(BaseTestCase):
+    def settings(self, **kwargs):
+        func = super().settings(**kwargs)
+        if 'eb_sqs_worker.app_settings' in sys.modules:
+            from eb_sqs_worker.app_settings import app_settings
+            app_settings.reconfigure()
+        return func
+
+
 class SQSLocaltestCase(TestCase):
-
-    def setUp(self):
-        pass
-
     def test_local_echo_task_sending(self):
         overrides = update_settings(
             AWS_EB_HANDLE_SQS_TASKS=False,

--- a/eb_sqs_worker/views.py
+++ b/eb_sqs_worker/views.py
@@ -3,16 +3,14 @@ import logging
 import time
 import uuid
 
-from django.conf import settings
 from django.core.mail import mail_admins
-from django.shortcuts import render
-
+from django.http import JsonResponse, Http404
 # Create your views here.
 from django.utils.decorators import method_decorator
 from django.views import View
-from django.http import JsonResponse, Http404, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 
+from eb_sqs_worker.app_settings import app_settings
 from eb_sqs_worker.sqs import SQSTask
 
 
@@ -26,7 +24,7 @@ class HandleSQSTaskView(View):
         :param request:
         :return:
         """
-        if not getattr(settings, "AWS_EB_HANDLE_SQS_TASKS", False):
+        if not app_settings.AWS_EB_HANDLE_SQS_TASKS:
             # if this django instance is not set to handle
             # incoming SQS tasks from Elastic Beanstalk SQS Daemon,
             # then ignore them as this may pose a security risk.
@@ -69,7 +67,7 @@ class HandleSQSTaskView(View):
         print(f"{call_id} Finished {task.get_pretty_info_string()}. "
               f"Result: {result}. Execution time: {execution_time}s.")
 
-        alert_threshold_seconds = getattr(settings, "AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS", None)
+        alert_threshold_seconds = app_settings.AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS
         if alert_threshold_seconds:
             if execution_time > alert_threshold_seconds:
                 try:

--- a/eb_sqs_worker/views.py
+++ b/eb_sqs_worker/views.py
@@ -10,8 +10,8 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
-from eb_sqs_worker.app_settings import app_settings
 from eb_sqs_worker.sqs import SQSTask
+from .app_settings import app_settings
 
 
 @method_decorator(csrf_exempt, name='dispatch')  # otherwise will hit csrf protection

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -10,7 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
-import os, sys
+import os
+import sys
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -124,8 +125,9 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 # eb-sqs-worker settings
-AWS_EB_DEFAULT_REGION = "us-west-1"
-AWS_ACCESS_KEY_ID = "dummy"
-AWS_SECRET_ACCESS_KEY = "dummy"
-
-AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS = 0.00000000000000000000000000000000000000000000000000000000001
+EB_SQS = {
+    'AWS_EB_DEFAULT_REGION': "us-west-1",
+    'AWS_ACCESS_KEY_ID': "dummy",
+    'AWS_SECRET_ACCESS_KEY': "dummy",
+    'AWS_EB_ALERT_WHEN_EXECUTES_LONGER_THAN_SECONDS': 0.00000000000000000000000000000000000000000000000000000000001
+}


### PR DESCRIPTION
Implements settings as an application specific entity that is hydrated from the Django settings. Similar patterns can be seen in packages such as all_auth.
Also moves settings to an EB_SQS dictionary and issues deprecation warning if found in the global namespace. (see #8 for reasoning).
Last but not least, implements a TODO: puts queues on the settings and caches them.